### PR TITLE
Simplify repo addressing

### DIFF
--- a/src/core/repos.rs
+++ b/src/core/repos.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 #[derive(Debug)]
 pub struct Repo<'a> {
     pub repo_owner: &'a str,
@@ -8,11 +9,21 @@ pub struct Repo<'a> {
 pub struct RepoRequest<'a>(pub Repo<'a>, pub &'a str);
 
 impl<'a> RepoRequest<'a> {
-    pub fn new(repo_owner: &'a str, repo_name: &'a str, auth_token: &'a str) -> Self {
+    pub fn try_from(repo_addr: &'a str, auth_token: &'a str) -> Result<Self> {
+        let slash_idx = repo_addr
+            .find('/')
+            .ok_or_else(|| anyhow!("Unable to parse repo_name from: {}", repo_addr))?;
+        let (repo_owner, repo_name) = repo_addr.split_at(slash_idx);
         let repo = Repo {
             repo_owner: &repo_owner,
-            repo_name: &repo_name,
+            repo_name: &repo_name[1..],
         };
-        RepoRequest(repo, &auth_token)
+        Ok(RepoRequest(repo, &auth_token))
+    }
+}
+
+impl std::fmt::Display for Repo<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}/{}", self.repo_owner, self.repo_name)
     }
 }


### PR DESCRIPTION
- Simplify repo addressing by combining `repo_owner` and `repo_name` into single param `repo_addr`.

Closes #19 