### PR TITLE
Add `build.rs` for codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 SECRET.txt
-graphql/schema/
-
+schema.public.graphql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "762e34611d2d5233a506a79072be944fddd057db2f18e04c0d6fa79e3fd466fd"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.31+curl-7.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcd62757cc4f5ab9404bc6ca9f0ae447e729a1403948ce5106bd588ceac6a3b0"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,12 +361,16 @@ dependencies = [
  "base64",
  "bytes",
  "clap",
+ "curl",
  "graphql_client",
+ "graphql_client_codegen",
  "hyper",
  "hyper-tls",
+ "quote",
  "serde",
  "serde_json",
  "sodiumoxide",
+ "syn",
  "tokio",
 ]
 
@@ -577,6 +611,18 @@ dependencies = [
  "libflate",
  "pkg-config",
  "tar",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
  "vcpkg",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,9 @@ base64 = "0.12.0"
 async-trait = "0.1.30"
 ansi_term = "0.12.1"
 graphql_client = "0.9.0"
+
+[build-dependencies]
+curl = "0.4.29"
+graphql_client_codegen = "0.9.0"
+syn = "1.0"
+quote = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,91 @@
+use curl::easy::Easy;
+use graphql_client_codegen::{
+    generate_module_token_stream, CodegenMode, GraphQLClientCodegenOptions,
+};
+use std::fs::File;
+use std::io::{BufWriter, Write as _};
+use std::path::PathBuf;
+use syn::Token;
+
+const GH_PUBLIC_SCHEMA_URL: &'static str =
+    "https://developer.github.com/v4/public_schema/schema.public.graphql";
+const SCHEMA_DOWNLOAD_PATH: &'static str = "graphql/schema.public.graphql";
+
+const OUTPUT_DIRECTORY_PATH: &'static str = "src/graphql/";
+
+// Queries
+const REPO_BASIC_INFO: &'static str = "graphql/query/repo_basic_info.graphql";
+
+fn main() {
+    println!("cargo:rerun-if-changed={}", REPO_BASIC_INFO);
+    download_schema();
+    generate_code(&REPO_BASIC_INFO);
+}
+
+fn generate_code(query_path: &str) {
+    let query_path = PathBuf::from(query_path);
+    let mut options = GraphQLClientCodegenOptions::new(CodegenMode::Cli);
+    options.set_module_visibility(
+        syn::VisPublic {
+            pub_token: <Token![pub]>::default(),
+        }
+        .into(),
+    );
+    let schema_path = PathBuf::from(SCHEMA_DOWNLOAD_PATH);
+    let gen = generate_module_token_stream(query_path.clone(), &schema_path, options)
+        .expect("Module token stream generation failed!");
+
+    let gen = quote::quote! {
+      type DateTime = String;
+      type URI = String;
+      #gen
+    };
+
+    let generated_code = gen.to_string();
+
+    let query_file_name: ::std::ffi::OsString = query_path
+        .file_name()
+        .map(ToOwned::to_owned)
+        .expect("Failed to find a file name in the provided query path.");
+
+    let dest_file_path: PathBuf = PathBuf::from(OUTPUT_DIRECTORY_PATH)
+        .join(query_file_name)
+        .with_extension("rs");
+
+    let mut file = File::create(dest_file_path).unwrap();
+    let file_write_err_msg = "Unable to write the generated code to file!";
+    writeln!(
+        file,
+        r###"// This is auto-generated using `build.rs` file! Do not modify!
+
+#![allow(clippy::redundant_static_lifetimes)]
+#![allow(unknown_lints)]
+"###
+    )
+    .expect(file_write_err_msg);
+    write!(file, "{}", generated_code).expect(file_write_err_msg);
+}
+
+fn download_schema() {
+    // Check if schema file exists in path
+    let schema_file_path = PathBuf::from(SCHEMA_DOWNLOAD_PATH);
+    if !schema_file_path.exists() {
+        // Download the file to the path!
+        let f = File::create(&schema_file_path).unwrap();
+        let mut writer = BufWriter::new(f);
+        let mut easy = Easy::new();
+        easy.url(&GH_PUBLIC_SCHEMA_URL).unwrap();
+        easy.write_function(move |data| Ok(writer.write(data).unwrap()))
+            .unwrap();
+        easy.perform().unwrap();
+        let response_code = easy.response_code().unwrap();
+        if response_code != 200 {
+            panic!(
+                "Unexpected response code {} for {}",
+                response_code, GH_PUBLIC_SCHEMA_URL
+            );
+        }
+    } else {
+        // Do nothing!
+    }
+}

--- a/src/graphql/repo_basic_info.rs
+++ b/src/graphql/repo_basic_info.rs
@@ -1,7 +1,11 @@
-/// Auto generated code using `graphql-client` CLI!
-pub struct RepoBasicInfoQuery;
-type URI = String;
+// This is auto-generated using `build.rs` file! Do not modify!
+
+#![allow(clippy::redundant_static_lifetimes)]
+#![allow(unknown_lints)]
+
 type DateTime = String;
+type URI = String;
+pub struct RepoBasicInfoQuery;
 pub mod repo_basic_info_query {
     #![allow(dead_code)]
     pub const OPERATION_NAME: &'static str = "RepoBasicInfoQuery";

--- a/src/utils/sealed_box.rs
+++ b/src/utils/sealed_box.rs
@@ -1,11 +1,10 @@
 use anyhow::{anyhow, Result};
-use base64;
 use sodiumoxide::crypto::{box_::curve25519xsalsa20poly1305::PublicKey, sealedbox};
 
 pub fn seal(message: &str, public_key_base64: &str) -> Result<String> {
     let public_key = base64::decode(public_key_base64)?;
-    let public_key =
-        PublicKey::from_slice(&public_key).ok_or(anyhow!("unable to create public key object"))?;
+    let public_key = PublicKey::from_slice(&public_key)
+        .ok_or_else(|| anyhow!("unable to create public key object"))?;
 
     let sealed_box = sealedbox::seal(message.as_bytes(), &public_key);
     let sealed_box_base64 = base64::encode(&sealed_box);


### PR DESCRIPTION
- Add `build.rs` to handle GraphQL query code generation using `graphql_client_codegen`.
- Download GH GraphQL public schema from URL using `rust-curl`.

Closes #24 