### PR TITLE
Add gh-auth for login

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --release --verbose
+      env:
+        GH_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+        GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:
@@ -26,6 +29,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --release --verbose
+      env:
+        GH_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+        GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:
@@ -38,6 +44,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --release --verbose
+      env:
+        GH_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+        GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,12 +525,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "gh-auth"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "hyper",
+ "hyper-tls",
+ "quote",
+ "rand 0.7.3",
+ "url",
+ "webbrowser",
+]
+
+[[package]]
 name = "gh-cli"
 version = "0.3.1"
 dependencies = [
  "ansi_term",
  "anyhow",
  "clap",
+ "gh-auth",
  "gh-lib",
  "lazy_static",
  "regex",
@@ -2039,6 +2054,22 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "webbrowser"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d468a911faaaeb783693b004e1c62e0063e646b0afae5c146cd144e566e66d"
+dependencies = [
+ "widestring",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "widestring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effc0e4ff8085673ea7b9b2e3c73f6bd4d118810c9009ed8f1e16bd96c331db6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,12 @@
 [workspace]
 members = [
   "gh-lib",
+  "gh-auth",
   "gh-cli",
   "gh-web"
 ]
 default-members = [
   "gh-lib",
+  "gh-auth",
   "gh-cli"
 ]

--- a/gh-auth/Cargo.toml
+++ b/gh-auth/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "gh-auth"
+version = "0.1.0"
+authors = ["Aslam Ahammed <aslamplr@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+hyper = "0.13"
+hyper-tls = "0.4.1"
+futures = "0.3"
+rand = "0.7"
+url = "2.1"
+webbrowser = "0.5.2"
+
+[build-dependencies]
+anyhow = "1.0"
+quote = "1.0"

--- a/gh-auth/build.rs
+++ b/gh-auth/build.rs
@@ -1,0 +1,27 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+fn main() -> anyhow::Result<()> {
+    let success_html = fs::read_to_string("success.html")?;
+    let client_id =
+        std::env::var("GH_OAUTH_CLIENT_ID").expect("Required to set env $GH_OAUTH_CLIENT_ID.");
+    let client_secret = std::env::var("GH_OAUTH_CLIENT_SECRET")
+        .expect("Required to set env $GH_OAUTH_CLIENT_SECRET.");
+
+    let generated_code = quote::quote! {
+      pub const OAUTH_HOST: &str = "github.com";
+      const SUCCESS_HTML: &str = #success_html;
+      pub const OAUTH_CLIENT_ID: &str = #client_id;
+      const OAUTH_CLIENT_SECRET: &str = #client_secret;
+    };
+    let out_dir = std::env::var_os("OUT_DIR").unwrap();
+    let dest_file_path: PathBuf = Path::new(&out_dir).join("constants").with_extension("rs");
+    let mut file = fs::File::create(dest_file_path)?;
+    write!(file, "{}", generated_code.to_string())?;
+    println!("cargo:rerun-if-env-changed=GH_OAUTH_CLIENT_ID");
+    println!("cargo:rerun-if-env-changed=GH_OAUTH_CLIENT_SECRET");
+    println!("cargo:rerun-if-changed=success.html");
+    println!("cargo:rerun-if-changed=build.rs");
+    Ok(())
+}

--- a/gh-auth/src/lib.rs
+++ b/gh-auth/src/lib.rs
@@ -1,0 +1,198 @@
+use anyhow::Result;
+use url::form_urlencoded::{parse, Serializer};
+
+include!(concat!(env!("OUT_DIR"), "/constants.rs"));
+
+pub async fn start_auth_flow() -> Result<String> {
+    let auth_flow = OAuthFlow::new(
+        OAUTH_HOST,
+        OAUTH_CLIENT_ID,
+        OAUTH_CLIENT_SECRET,
+        vec!["repo", "read:org", "workflow", "gist"],
+        SUCCESS_HTML,
+    );
+    auth_flow.obtain_access_token().await
+}
+
+/// Roughly based on cli/cli the official gh cli implementation in Go!
+/// https://github.com/cli/cli/blob/658d548c5e690b4fb4dd6ac06d4b798238b6157f/auth/oauth.go#L29
+pub struct OAuthFlow<'a> {
+    host_name: &'a str,
+    client_id: &'a str,
+    client_secret: &'a str,
+    scopes: Vec<&'a str>,
+    success_html: &'a str,
+}
+
+impl OAuthFlow<'_> {
+    pub fn new<'a>(
+        host_name: &'a str,
+        client_id: &'a str,
+        client_secret: &'a str,
+        scopes: Vec<&'a str>,
+        success_html: &'a str,
+    ) -> OAuthFlow<'a> {
+        OAuthFlow {
+            host_name,
+            client_id,
+            client_secret,
+            scopes,
+            success_html,
+        }
+    }
+
+    pub async fn obtain_access_token(&self) -> Result<String> {
+        let state = utils::generate_random_string(20);
+        let port = 19878;
+        let query = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("client_id", self.client_id)
+            .append_pair(
+                "redirect_uri",
+                &format!("http://127.0.0.1:{}/callback", port),
+            )
+            .append_pair("scope", &self.scopes.join(" "))
+            .append_pair("state", &state)
+            .finish();
+
+        let url = hyper::Uri::builder()
+            .scheme("https")
+            .authority(self.host_name)
+            .path_and_query(format!("/login/oauth/authorize?{}", query).as_str())
+            .build()?
+            .to_string();
+
+        if webbrowser::open(&url).is_err() {
+            // handle browser not open case
+            eprintln!("[Auth] Error opening the brower\n");
+            eprintln!("Please open the following URL manually:\n{}\n", url);
+        }
+
+        let access_token = {
+            use futures::channel::oneshot;
+            use hyper::{
+                body::to_bytes,
+                service::{make_service_fn, service_fn},
+                Body, Client, Method, Request, Response, Server, StatusCode, Uri,
+            };
+            use std::sync::{Arc, Mutex};
+
+            let success_html = self.success_html.to_owned();
+
+            let (shutdown_server_send, shutdown_server_recv) = oneshot::channel::<()>();
+            let (auth_code_send, auth_code_recv) = oneshot::channel::<(String, String)>();
+            let auth_code_send = Arc::new(Mutex::new(Some(auth_code_send)));
+            let original_state = Arc::new(Mutex::new(state));
+
+            let service = make_service_fn(move |_| {
+                let original_state = original_state.clone();
+                let auth_code_send = auth_code_send.clone();
+                let success_html = success_html.to_owned();
+
+                async move {
+                    Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
+                        let original_state = original_state.clone();
+                        let auth_code_send = auth_code_send.clone();
+                        let success_html = success_html.to_owned();
+
+                        async move {
+                            match (req.method(), req.uri().path()) {
+                                (&Method::GET, "/callback") => {
+                                    // Get `state` & `code` from query.
+                                    let query = req.uri().query().unwrap_or("");
+                                    let parsed = parse(query.as_bytes());
+                                    let state_recvd = utils::get_item_from_parse(parsed, "state");
+                                    let original_state = original_state.lock().unwrap().to_string();
+                                    if state_recvd == original_state {
+                                        if let Some(auth_code_send) =
+                                            auth_code_send.lock().unwrap().take()
+                                        {
+                                            let code = utils::get_item_from_parse(parsed, "code");
+                                            let _ = auth_code_send.send((code, state_recvd));
+                                        }
+                                        Ok::<_, hyper::Error>(Response::new(Body::from(
+                                            success_html,
+                                        )))
+                                    } else {
+                                        Ok::<_, hyper::Error>(Response::new(Body::from(
+                                            "Error: state mismatch",
+                                        )))
+                                    }
+                                }
+                                _ => {
+                                    let mut not_found = Response::default();
+                                    *not_found.status_mut() = StatusCode::NOT_FOUND;
+                                    Ok::<_, hyper::Error>(not_found)
+                                }
+                            }
+                        }
+                    }))
+                }
+            });
+
+            let addr = ([127, 0, 0, 1], port).into();
+            let server = Server::bind(&addr).serve(service);
+            let graceful = server.with_graceful_shutdown(async {
+                shutdown_server_recv.await.ok();
+            });
+
+            let capture_code = async {
+                let (code, state) = auth_code_recv.await?;
+                let _ = shutdown_server_send.send(());
+                let token_url = Uri::builder()
+                    .scheme("https")
+                    .authority(self.host_name)
+                    .path_and_query("/login/oauth/access_token")
+                    .build()?;
+                let client = Client::builder().build::<_, Body>(hyper_tls::HttpsConnector::new());
+                let form_encoded = Serializer::new(String::new())
+                    .append_pair("client_id", self.client_id)
+                    .append_pair("client_secret", self.client_secret)
+                    .append_pair("code", &code)
+                    .append_pair("state", &state)
+                    .finish();
+                let req = Request::builder()
+                    .method(Method::POST)
+                    .uri(token_url)
+                    .body(Body::from(form_encoded))?;
+                let resp = client.request(req).await?;
+                let resp = to_bytes(resp.into_body()).await?;
+                let parsed = parse(&resp);
+                let access_token = utils::get_item_from_parse(parsed, "access_token");
+                Ok::<_, anyhow::Error>(access_token)
+            };
+
+            println!("[Auth] Listening on http://{}", addr);
+            let (graceful, access_token) = futures::join!(graceful, capture_code);
+
+            if let Err(e) = graceful {
+                eprintln!("[Auth] Server error: {}", e);
+            }
+
+            access_token?
+        };
+
+        Ok(access_token)
+    }
+}
+
+mod utils {
+    use rand::distributions::Alphanumeric;
+    use rand::{thread_rng, Rng};
+    use std::iter;
+    use url::form_urlencoded::Parse;
+
+    pub(crate) fn generate_random_string(length: usize) -> String {
+        let mut rng = thread_rng();
+        iter::repeat(())
+            .map(|()| rng.sample(Alphanumeric))
+            .take(length)
+            .collect()
+    }
+
+    pub(crate) fn get_item_from_parse(iter: Parse, key: &str) -> String {
+        iter.clone()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.to_string())
+            .unwrap_or_default()
+    }
+}

--- a/gh-auth/success.html
+++ b/gh-auth/success.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Success: GH-CLI</title>
+<style type="text/css">
+  body {
+    color: #1B1F23;
+    background: #F6F8FA;
+    font-size: 14px;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    line-height: 1.5;
+    max-width: 620px;
+    margin: 28px auto;
+    text-align: center;
+  }
+
+  h1 {
+    font-size: 24px;
+    margin-bottom: 0;
+  }
+
+  p {
+    margin-top: 0;
+  }
+
+  .box {
+    border: 1px solid #E1E4E8;
+    background: white;
+    padding: 24px;
+    margin: 28px;
+  }
+</style>
+
+<body>
+  <svg height="52" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="52" aria-hidden="true">
+    <path fill-rule="evenodd"
+      d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z">
+    </path>
+  </svg>
+  <div class="box">
+    <h1>Successfully authenticated using GitHub for GH-CLI</h1>
+    <p>You may now close this tab and return to the terminal.</p>
+  </div>
+</body>

--- a/gh-cli/Cargo.toml
+++ b/gh-cli/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { version = "0.2", features = ["full"] }
 ansi_term = "0.12.1"
 lazy_static = "1.4.0"
 gh-lib = { path = "../gh-lib" }
+gh-auth = { path = "../gh-auth" }

--- a/gh-cli/src/main.rs
+++ b/gh-cli/src/main.rs
@@ -29,6 +29,8 @@ struct Opts {
 
 #[derive(Clap)]
 enum SubCommand {
+    #[clap(about = "Login using GitHub OAuth (requires web browser)")]
+    Login,
     Repo(Repo),
     Secrets(Secrets),
 }
@@ -117,6 +119,18 @@ async fn main() -> anyhow::Result<()> {
     let opts: Opts = Opts::parse();
 
     match opts.subcmd {
+        SubCommand::Login => {
+            let access_token = gh_auth::start_auth_flow().await?;
+            eprintln!("# Run the following to use the access token in subesquent requests!\n");
+            println!("export GH_ACCESS_TOKEN={}", access_token);
+            eprintln!("");
+            let oauth_host = gh_auth::OAUTH_HOST;
+            let client_id = gh_auth::OAUTH_CLIENT_ID;
+            eprintln!(
+                "# Review or revoke access visit - https://{}/settings/connections/applications/{}",
+                oauth_host, client_id
+            );
+        }
         SubCommand::Repo(repo) => {
             let Repo { name, auth_token } = repo;
             let repo = RepoRequest::try_from(&name, &auth_token)?;


### PR DESCRIPTION
- Add `login` subcommand.
- Implement login using GitHub OAuth flow login.
- `gh-auth` roughly implements how it is done in official `cli/cli` in Golang.

Closes #26 