### PR TITLE
Refactor: use reqwest instead of hyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,15 +357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
-dependencies = [
- "sct",
-]
-
-[[package]]
 name = "curl"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,10 +420,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dtoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "extend"
@@ -628,9 +634,9 @@ dependencies = [
  "anyhow",
  "futures",
  "hyper",
- "hyper-rustls",
  "quote",
  "rand",
+ "reqwest",
  "url",
  "webbrowser",
 ]
@@ -660,14 +666,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.12.2",
- "bytes",
  "chrono",
  "curl",
  "graphql_client",
- "hyper",
- "hyper-rustls",
  "macros",
  "mockito",
+ "reqwest",
  "serde",
  "serde_json",
  "sodiumoxide",
@@ -837,7 +841,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
  "bytes",
- "ct-logs",
  "futures-util",
  "hyper",
  "log",
@@ -845,7 +848,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1016,6 +1018,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -1419,6 +1437,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
+name = "reqwest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
+dependencies = [
+ "base64 0.12.2",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1615,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
 ]
 
 [[package]]
@@ -1837,6 +1903,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +2020,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -1961,6 +2038,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64487204d863f109eb77e8462189d111f27cb5712cc9fdb3461297a76963a2f6"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2079,6 +2168,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "ws2_32-sys"

--- a/gh-auth/Cargo.toml
+++ b/gh-auth/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 hyper = "0.13"
-hyper-rustls = { version = "0.20.0", default-features = false, features = [ "webpki-tokio" ] }
+reqwest = { version = "0.10", default-features = false, features = ["json", "rustls-tls"]}
 futures = "0.3"
 rand = "0.7"
 url = "2.1"

--- a/gh-cli/src/main.rs
+++ b/gh-cli/src/main.rs
@@ -46,11 +46,9 @@ fn get_git_addr_from_repo() -> anyhow::Result<String> {
         .args(&["config", "--get", "remote.origin.url"])
         .output()?
         .stdout;
-    lazy_static::lazy_static! {
-        static ref RE: regex::Regex = regex::Regex::new(r"github\.com[:/](\S+)/(\S+)\.git").unwrap();
-    }
+    let re = regex::Regex::new(r"github\.com[:/](\S+)/(\S+)\.git").unwrap();
     let regex_cap_err = || anyhow::anyhow!("Unable to capture github git repo!");
-    RE.captures(std::str::from_utf8(&output)?)
+    re.captures(std::str::from_utf8(&output)?)
         .and_then(|caps| {
             match (
                 caps.get(1).map(|c| c.as_str()),

--- a/gh-lib/Cargo.toml
+++ b/gh-lib/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/aslamplr/gh-cli"
 
 [features]
-http-api = [ "hyper", "hyper-rustls", "bytes" ]
+http-api = [ "reqwest" ]
 graphql-api = [ "graphql_client", "http-api", "macros" ]
 workflows = [ "http-api" ]
 secrets = [ "http-api" ]
@@ -26,9 +26,7 @@ async-trait = "0.1.36"
 url = "2.1"
 
 # http-api
-hyper = { version = "0.13", optional = true }
-hyper-rustls = { version = "0.20.0", default-features = false, features = [ "webpki-tokio" ], optional = true }
-bytes = { version = "0.5", optional = true }
+reqwest = { version = "0.10", default-features = false, features = ["json", "rustls-tls"], optional = true }
 # graphql-api
 graphql_client = { version = "0.9.0", optional = true }
 macros = { path = "macros", optional = true }

--- a/gh-lib/src/core/basic_info.rs
+++ b/gh-lib/src/core/basic_info.rs
@@ -43,7 +43,7 @@ impl BasicInfo for RepoRequest<'_> {
             &with_base_url!("{}/readme", repo),
             HttpMethod::GET,
             auth_token,
-        )
+        )?
         .header("Accept", "application/vnd.github.VERSION.raw")
         .call()
         .await?;
@@ -65,7 +65,7 @@ mod tests {
         let m = mock("POST", "/graphql")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .with_header("content-type", "application/json")
@@ -132,7 +132,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/readme")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .match_header("Accept", "application/vnd.github.VERSION.raw")
             .with_status(201)

--- a/gh-lib/src/core/basic_info.rs
+++ b/gh-lib/src/core/basic_info.rs
@@ -30,29 +30,17 @@ impl From<&Repo<'_>> for basic_info_response::Variables {
 #[async_trait]
 impl BasicInfo for RepoRequest<'_> {
     async fn get_basic_info(&self) -> Result<BasicInfoResponse> {
-        let RepoRequest {
-            repo,
-            auth_token,
-            http_client,
-        } = self;
+        let RepoRequest { repo, http_client } = self;
         let graphql_query = RepoBasicInfoQuery::build_query(repo.into());
-        let resp = query_graphql(http_client, graphql_query, &auth_token).await?;
+        let resp = query_graphql(http_client, graphql_query).await?;
         resp.data
             .ok_or_else(|| anyhow::anyhow!("Couldn't find repository basic information!"))
     }
 
     async fn get_raw_readme(&self) -> Result<String> {
-        let RepoRequest {
-            repo,
-            auth_token,
-            http_client,
-        } = self;
+        let RepoRequest { repo, http_client } = self;
         let resp = http_client
-            .request(
-                &with_base_url!("{}/readme", repo),
-                HttpMethod::GET,
-                auth_token,
-            )
+            .request(&with_base_url!("{}/readme", repo), HttpMethod::GET)
             .header("Accept", "application/vnd.github.VERSION.raw")
             .call()
             .await?;

--- a/gh-lib/src/core/basic_info.rs
+++ b/gh-lib/src/core/basic_info.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "basic-info")]
 use super::repos::{Repo, RepoRequest};
 pub use crate::graphql::repo_basic_info::repo_basic_info_query as basic_info_response;
-use crate::utils::http::{request, HttpMethod};
+use crate::utils::http::HttpMethod;
 use crate::{graphql::repo_basic_info::RepoBasicInfoQuery, utils::graphql::query_graphql};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -30,23 +30,32 @@ impl From<&Repo<'_>> for basic_info_response::Variables {
 #[async_trait]
 impl BasicInfo for RepoRequest<'_> {
     async fn get_basic_info(&self) -> Result<BasicInfoResponse> {
-        let RepoRequest(repo, auth_token) = self;
+        let RepoRequest {
+            repo,
+            auth_token,
+            http_client,
+        } = self;
         let graphql_query = RepoBasicInfoQuery::build_query(repo.into());
-        let resp = query_graphql(graphql_query, &auth_token).await?;
+        let resp = query_graphql(http_client, graphql_query, &auth_token).await?;
         resp.data
             .ok_or_else(|| anyhow::anyhow!("Couldn't find repository basic information!"))
     }
 
     async fn get_raw_readme(&self) -> Result<String> {
-        let RepoRequest(repo, auth_token) = self;
-        let resp = request(
-            &with_base_url!("{}/readme", repo),
-            HttpMethod::GET,
+        let RepoRequest {
+            repo,
             auth_token,
-        )?
-        .header("Accept", "application/vnd.github.VERSION.raw")
-        .call()
-        .await?;
+            http_client,
+        } = self;
+        let resp = http_client
+            .request(
+                &with_base_url!("{}/readme", repo),
+                HttpMethod::GET,
+                auth_token,
+            )
+            .header("Accept", "application/vnd.github.VERSION.raw")
+            .call()
+            .await?;
         resp.body().await
     }
 }

--- a/gh-lib/src/core/repos.rs
+++ b/gh-lib/src/core/repos.rs
@@ -9,9 +9,8 @@ pub struct Repo<'a> {
 
 #[derive(Debug)]
 pub struct RepoRequest<'a> {
-    pub repo: Repo<'a>,
-    pub auth_token: &'a str,
-    pub http_client: HttpClient,
+    pub(crate) repo: Repo<'a>,
+    pub(crate) http_client: HttpClient,
 }
 
 impl<'a> RepoRequest<'a> {
@@ -24,12 +23,8 @@ impl<'a> RepoRequest<'a> {
             repo_owner: &repo_owner,
             repo_name: &repo_name[1..],
         };
-        let http_client = HttpClient::new()?;
-        Ok(RepoRequest {
-            repo,
-            auth_token,
-            http_client,
-        })
+        let http_client = HttpClient::new(auth_token)?;
+        Ok(RepoRequest { repo, http_client })
     }
 }
 

--- a/gh-lib/src/core/repos.rs
+++ b/gh-lib/src/core/repos.rs
@@ -1,4 +1,6 @@
+use crate::utils::http::HttpClient;
 use anyhow::{anyhow, Result};
+
 #[derive(Debug)]
 pub struct Repo<'a> {
     pub repo_owner: &'a str,
@@ -6,7 +8,11 @@ pub struct Repo<'a> {
 }
 
 #[derive(Debug)]
-pub struct RepoRequest<'a>(pub Repo<'a>, pub &'a str);
+pub struct RepoRequest<'a> {
+    pub repo: Repo<'a>,
+    pub auth_token: &'a str,
+    pub http_client: HttpClient,
+}
 
 impl<'a> RepoRequest<'a> {
     pub fn try_from(repo_addr: &'a str, auth_token: &'a str) -> Result<Self> {
@@ -18,7 +24,12 @@ impl<'a> RepoRequest<'a> {
             repo_owner: &repo_owner,
             repo_name: &repo_name[1..],
         };
-        Ok(RepoRequest(repo, &auth_token))
+        let http_client = HttpClient::new()?;
+        Ok(RepoRequest {
+            repo,
+            auth_token,
+            http_client,
+        })
     }
 }
 

--- a/gh-lib/src/core/secrets.rs
+++ b/gh-lib/src/core/secrets.rs
@@ -106,13 +106,9 @@ async fn get_from_gh<T>(path: &str, params: &RepoRequest<'_>) -> Result<T>
 where
     T: serde::de::DeserializeOwned,
 {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/{}", repo, path);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
@@ -135,30 +131,18 @@ async fn put_gh_secret(
     name: &str,
     secret_save_req: &SecretSaveRequest,
 ) -> Result<()> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/secrets/{}", repo, name);
     http_client
-        .put(
-            &url,
-            HttpBody::try_from_serialize(&secret_save_req)?,
-            auth_token,
-        )
+        .put(&url, HttpBody::try_from_serialize(&secret_save_req)?)
         .await?;
     Ok(())
 }
 
 async fn delete_a_secret(params: &RepoRequest<'_>, name: &str) -> Result<()> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/secrets/{}", repo, name);
-    http_client.delete(&url, &auth_token).await?;
+    http_client.delete(&url).await?;
     Ok(())
 }
 

--- a/gh-lib/src/core/secrets.rs
+++ b/gh-lib/src/core/secrets.rs
@@ -163,7 +163,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/secrets")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .with_header("content-type", "application/json")
@@ -219,7 +219,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/secrets/GH_TOKEN")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .with_header("content-type", "application/json")
@@ -255,7 +255,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/secrets/public-key")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .with_header("content-type", "application/json")
@@ -298,7 +298,7 @@ mod tests {
         let m1 = mock("GET", "/aslamplr/gh-cli/actions/secrets/public-key")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .with_header("content-type", "application/json")
@@ -315,7 +315,7 @@ mod tests {
         let m2 = mock("PUT", "/aslamplr/gh-cli/actions/secrets/GH_TOKEN")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .match_body(Matcher::Regex("encrypted_value".to_string()))
             .match_body(Matcher::Regex("key_id".to_string()))
@@ -340,7 +340,7 @@ mod tests {
         let m = mock("DELETE", "/aslamplr/gh-cli/actions/secrets/GH_TOKEN")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(204)
             .with_header("content-type", "application/json")

--- a/gh-lib/src/core/workflow_jobs.rs
+++ b/gh-lib/src/core/workflow_jobs.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "workflows")]
 use super::repos::RepoRequest;
-use crate::utils::http::get;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -80,25 +79,37 @@ async fn get_workflow_run_jobs(
     params: &RepoRequest<'_>,
     run_id: u32,
 ) -> Result<WorkflowRunJobList> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/runs/{}/jobs", repo, run_id);
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_a_workflow_run_job(params: &RepoRequest<'_>, job_id: u32) -> Result<WorkflowRunJob> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/jobs/{}", repo, job_id);
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_job_logs_url(params: &RepoRequest<'_>, job_id: u32) -> Result<String> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/jobs/{}/logs", repo, job_id);
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     let resp = resp.get_header("Location");
     resp.ok_or_else(|| anyhow::anyhow!("Location header with log url not found in response!"))
 }

--- a/gh-lib/src/core/workflow_jobs.rs
+++ b/gh-lib/src/core/workflow_jobs.rs
@@ -79,37 +79,25 @@ async fn get_workflow_run_jobs(
     params: &RepoRequest<'_>,
     run_id: u32,
 ) -> Result<WorkflowRunJobList> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/runs/{}/jobs", repo, run_id);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_a_workflow_run_job(params: &RepoRequest<'_>, job_id: u32) -> Result<WorkflowRunJob> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/jobs/{}", repo, job_id);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_job_logs_url(params: &RepoRequest<'_>, job_id: u32) -> Result<String> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/jobs/{}/logs", repo, job_id);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.get_header("Location");
     resp.ok_or_else(|| anyhow::anyhow!("Location header with log url not found in response!"))
 }

--- a/gh-lib/src/core/workflow_jobs.rs
+++ b/gh-lib/src/core/workflow_jobs.rs
@@ -116,7 +116,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/runs/29679449/jobs")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .with_header("content-type", "application/json")
@@ -217,7 +217,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/jobs/399444496")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .with_header("content-type", "application/json")
@@ -308,7 +308,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/jobs/399444496/logs")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(302)
             .with_header("Location", "https://pipelines.actions.githubusercontent.com/ab1f3cCFPB34Nd6imvFxpGZH5hNlDp2wijMwl2gDoO0bcrrlJj/_apis/pipelines/1/jobs/19/signedlogcontent?urlExpires=2020-01-22T22%3A44%3A54.1389777Z&urlSigningMethod=HMACV1&urlSignature=2TUDfIg4fm36OJmfPy6km5QD5DLCOkBVzvhWZM8B%2BUY%3D")

--- a/gh-lib/src/core/workflow_runs.rs
+++ b/gh-lib/src/core/workflow_runs.rs
@@ -255,11 +255,7 @@ async fn get_workflow_runs(
     workflow_id: Option<u32>,
     filter: Option<&WorkflowRunQueryParams<'_>>,
 ) -> Result<WorkflowRunList> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = if let Some(workflow_id) = workflow_id {
         with_base_url!("{}/actions/workflows/{}/runs", repo, workflow_id)
     } else {
@@ -286,80 +282,52 @@ async fn get_workflow_runs(
     } else {
         url
     };
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_a_workflow_run(params: &RepoRequest<'_>, run_id: u32) -> Result<WorkflowRun> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/runs/{}", repo, run_id);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn rerun_a_workflow(params: &RepoRequest<'_>, run_id: u32) -> Result<()> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/runs/{}/rerun", repo, run_id);
-    http_client
-        .post(&url, HttpBody::empty(), &auth_token)
-        .await?;
+    http_client.post(&url, HttpBody::empty()).await?;
     Ok(())
 }
 
 async fn cancel_a_workflow_run(params: &RepoRequest<'_>, run_id: u32) -> Result<()> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/runs/{}/cancel", repo, run_id);
-    http_client
-        .post(&url, HttpBody::empty(), &auth_token)
-        .await?;
+    http_client.post(&url, HttpBody::empty()).await?;
     Ok(())
 }
 
 async fn get_run_logs_url(params: &RepoRequest<'_>, run_id: u32) -> Result<String> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/runs/{}/logs", repo, run_id);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.get_header("Location");
     resp.ok_or_else(|| anyhow::anyhow!("Location header with log url not found in response!"))
 }
 
 async fn delete_run_logs(params: &RepoRequest<'_>, run_id: u32) -> Result<()> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/runs/{}/logs", repo, run_id);
-    http_client.delete(&url, &auth_token).await?;
+    http_client.delete(&url).await?;
     Ok(())
 }
 
 async fn get_workflow_run_usage(params: &RepoRequest<'_>, run_id: u32) -> Result<WorkflowRunUsage> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/runs/{}/timing", repo, run_id);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }

--- a/gh-lib/src/core/workflow_runs.rs
+++ b/gh-lib/src/core/workflow_runs.rs
@@ -340,7 +340,7 @@ mod tests {
     fn create_basic_mock_http(path: &str, auth_token: &str) -> mockito::Mock {
         mock("GET", path).match_header(
             "Authorization",
-            Matcher::Exact(format!("bearer {}", auth_token)),
+            Matcher::Exact(format!("Bearer {}", auth_token)),
         )
     }
 
@@ -832,7 +832,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/runs/30433642")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_header("content-type", "application/json")
             .with_body(
@@ -1031,7 +1031,7 @@ mod tests {
         let m = mock("POST", "/aslamplr/gh-cli/actions/runs/30433642/rerun")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .expect(1)
@@ -1053,7 +1053,7 @@ mod tests {
         let m = mock("POST", "/aslamplr/gh-cli/actions/runs/30433642/cancel")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(202)
             .expect(1)
@@ -1075,7 +1075,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/runs/30433642/logs")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(302)
             .with_header("Location", "https://pipelines.actions.githubusercontent.com/ab1f3cCFPB34Nd6imvFxpGZH5hNlDp2wijMwl2gDoO0bcrrlJj/_apis/pipelines/1/runs/19/signedlogcontent?urlExpires=2020-01-22T22%3A44%3A54.1389777Z&urlSigningMethod=HMACV1&urlSignature=2TUDfIg4fm36OJmfPy6km5QD5DLCOkBVzvhWZM8B%2BUY%3D")
@@ -1098,7 +1098,7 @@ mod tests {
         let m = mock("DELETE", "/aslamplr/gh-cli/actions/runs/30433642/logs")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(204)
             .expect(1)
@@ -1120,7 +1120,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/runs/30433642/timing")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .with_header("content-type", "application/json")

--- a/gh-lib/src/core/workflow_runs.rs
+++ b/gh-lib/src/core/workflow_runs.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "workflows")]
 use super::repos::RepoRequest;
-use crate::utils::http::{delete, get, post, HttpBody};
+use crate::utils::http::HttpBody;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -255,7 +255,11 @@ async fn get_workflow_runs(
     workflow_id: Option<u32>,
     filter: Option<&WorkflowRunQueryParams<'_>>,
 ) -> Result<WorkflowRunList> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = if let Some(workflow_id) = workflow_id {
         with_base_url!("{}/actions/workflows/{}/runs", repo, workflow_id)
     } else {
@@ -282,52 +286,80 @@ async fn get_workflow_runs(
     } else {
         url
     };
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_a_workflow_run(params: &RepoRequest<'_>, run_id: u32) -> Result<WorkflowRun> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/runs/{}", repo, run_id);
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn rerun_a_workflow(params: &RepoRequest<'_>, run_id: u32) -> Result<()> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/runs/{}/rerun", repo, run_id);
-    post(&url, HttpBody::empty(), &auth_token).await?;
+    http_client
+        .post(&url, HttpBody::empty(), &auth_token)
+        .await?;
     Ok(())
 }
 
 async fn cancel_a_workflow_run(params: &RepoRequest<'_>, run_id: u32) -> Result<()> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/runs/{}/cancel", repo, run_id);
-    post(&url, HttpBody::empty(), &auth_token).await?;
+    http_client
+        .post(&url, HttpBody::empty(), &auth_token)
+        .await?;
     Ok(())
 }
 
 async fn get_run_logs_url(params: &RepoRequest<'_>, run_id: u32) -> Result<String> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/runs/{}/logs", repo, run_id);
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     let resp = resp.get_header("Location");
     resp.ok_or_else(|| anyhow::anyhow!("Location header with log url not found in response!"))
 }
 
 async fn delete_run_logs(params: &RepoRequest<'_>, run_id: u32) -> Result<()> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/runs/{}/logs", repo, run_id);
-    delete(&url, &auth_token).await?;
+    http_client.delete(&url, &auth_token).await?;
     Ok(())
 }
 
 async fn get_workflow_run_usage(params: &RepoRequest<'_>, run_id: u32) -> Result<WorkflowRunUsage> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/runs/{}/timing", repo, run_id);
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }

--- a/gh-lib/src/core/workflows.rs
+++ b/gh-lib/src/core/workflows.rs
@@ -123,7 +123,7 @@ mod tests {
         let auth_token = "auth_secret_token";
 
         let m = mock("GET", "/aslamplr/gh-cli/actions/workflows")
-            .match_header("Authorization", Matcher::Exact(format!("bearer {}", auth_token)))
+            .match_header("Authorization", Matcher::Exact(format!("Bearer {}", auth_token)))
             .with_status(201)
             .with_header("content-type", "application/json")
             .with_body(r#"{
@@ -211,7 +211,7 @@ mod tests {
         let workflow_id = 161335;
 
         let m = mock("GET", "/aslamplr/gh-cli/actions/workflows/161335")
-            .match_header("Authorization", Matcher::Exact(format!("bearer {}", auth_token)))
+            .match_header("Authorization", Matcher::Exact(format!("Bearer {}", auth_token)))
             .with_status(201)
             .with_header("content-type", "application/json")
             .with_body(r#"{
@@ -260,7 +260,7 @@ mod tests {
         let m = mock("GET", "/aslamplr/gh-cli/actions/workflows/161335/timing")
             .match_header(
                 "Authorization",
-                Matcher::Exact(format!("bearer {}", auth_token)),
+                Matcher::Exact(format!("Bearer {}", auth_token)),
             )
             .with_status(201)
             .with_header("content-type", "application/json")

--- a/gh-lib/src/core/workflows.rs
+++ b/gh-lib/src/core/workflows.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "workflows")]
 use super::repos::RepoRequest;
-use crate::utils::http::get;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -87,25 +86,37 @@ pub struct WorkflowUsageTiming {
 }
 
 async fn get_all_workflows(params: &RepoRequest<'_>) -> Result<WorkflowList> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/workflows", repo);
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_a_workflow(params: &RepoRequest<'_>, workflow_id: u32) -> Result<Workflow> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/workflows/{}", repo, workflow_id);
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_workflow_usage(params: &RepoRequest<'_>, workflow_id: u32) -> Result<WorkflowUsage> {
-    let RepoRequest(repo, auth_token) = params;
+    let RepoRequest {
+        repo,
+        auth_token,
+        http_client,
+    } = params;
     let url = with_base_url!("{}/actions/workflows/{}/timing", repo, workflow_id);
-    let resp = get(&url, &auth_token).await?;
+    let resp = http_client.get(&url, &auth_token).await?;
     // eprintln!("body: {:?}", resp.body().await);
     // Err(anyhow::anyhow!("Error!"))
     let resp = resp.deserialize().await?;

--- a/gh-lib/src/core/workflows.rs
+++ b/gh-lib/src/core/workflows.rs
@@ -86,37 +86,25 @@ pub struct WorkflowUsageTiming {
 }
 
 async fn get_all_workflows(params: &RepoRequest<'_>) -> Result<WorkflowList> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/workflows", repo);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_a_workflow(params: &RepoRequest<'_>, workflow_id: u32) -> Result<Workflow> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/workflows/{}", repo, workflow_id);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     let resp = resp.deserialize().await?;
     Ok(resp)
 }
 
 async fn get_workflow_usage(params: &RepoRequest<'_>, workflow_id: u32) -> Result<WorkflowUsage> {
-    let RepoRequest {
-        repo,
-        auth_token,
-        http_client,
-    } = params;
+    let RepoRequest { repo, http_client } = params;
     let url = with_base_url!("{}/actions/workflows/{}/timing", repo, workflow_id);
-    let resp = http_client.get(&url, &auth_token).await?;
+    let resp = http_client.get(&url).await?;
     // eprintln!("body: {:?}", resp.body().await);
     // Err(anyhow::anyhow!("Error!"))
     let resp = resp.deserialize().await?;

--- a/gh-lib/src/utils/graphql.rs
+++ b/gh-lib/src/utils/graphql.rs
@@ -9,7 +9,6 @@ const BASE_URL: &str = crate::BASE_URL;
 pub async fn query_graphql<T, U>(
     http_client: &HttpClient,
     query: QueryBody<T>,
-    auth_token: &str,
 ) -> Result<Response<U>>
 where
     T: serde::Serialize,
@@ -17,9 +16,5 @@ where
 {
     let body = HttpBody::try_from_serialize(&query)?;
     let url = with_base_url!("graphql");
-    http_client
-        .post(&url, body, auth_token)
-        .await?
-        .deserialize()
-        .await
+    http_client.post(&url, body).await?.deserialize().await
 }

--- a/gh-lib/src/utils/graphql.rs
+++ b/gh-lib/src/utils/graphql.rs
@@ -1,17 +1,25 @@
 #![cfg(feature = "graphql-api")]
-use super::http::{post, HttpBody};
+use super::http::{HttpBody, HttpClient};
 use anyhow::Result;
 use graphql_client::{QueryBody, Response};
 
 #[cfg(not(test))]
 const BASE_URL: &str = crate::BASE_URL;
 
-pub async fn query_graphql<T, U>(query: QueryBody<T>, auth_token: &str) -> Result<Response<U>>
+pub async fn query_graphql<T, U>(
+    http_client: &HttpClient,
+    query: QueryBody<T>,
+    auth_token: &str,
+) -> Result<Response<U>>
 where
     T: serde::Serialize,
     U: serde::de::DeserializeOwned,
 {
     let body = HttpBody::try_from_serialize(&query)?;
     let url = with_base_url!("graphql");
-    post(&url, body, auth_token).await?.deserialize().await
+    http_client
+        .post(&url, body, auth_token)
+        .await?
+        .deserialize()
+        .await
 }


### PR DESCRIPTION
- Use reqwest for HTTP client and remove direct dependency over hyper and tls implementations.
- Add HttpClient wrapper and initialized in RepoRequest to ensure single http_client for any request chain.
- Initialize http_client in RepoRequest with auth_token and avoid all plumbing of auth_token.
- Remove unwanted lazy_static initialization of Regex for git repo name extraction. Which is used only once.